### PR TITLE
Add: reflowable?

### DIFF
--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -406,6 +406,11 @@ module ONIX
       @form_details.select{|fd| fd.code =~ /^E1.*/}
     end
 
+    def reflowable?
+      return true if @form_details.select{|fd| fd.code == "E200"}.length > 0
+      return false if @form_details.select{|fd| fd.code == "E201"}.length > 0
+    end
+
     def file_description
       @form_description
     end

--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -138,6 +138,11 @@ module ONIX
       @form_details.select{|fd| fd.code =~ /^E1.*/}
     end
 
+    def reflowable?
+      return true if @form_details.select{|fd| fd.code == "E200"}.length > 0
+      return false if @form_details.select{|fd| fd.code == "E201"}.length > 0
+    end
+
     # :category: High level
     # part file description string
     def file_description

--- a/lib/onix/product.rb
+++ b/lib/onix/product.rb
@@ -225,6 +225,10 @@ module ONIX
       @descriptive_detail.file_format
     end
 
+    def reflowable?
+      return @descriptive_detail.reflowable?
+    end
+
     # :category: High level
     # digital file mimetype (Epub,Pdf,Mobipocket)
     def file_mimetype

--- a/test/fixtures/fixed_layout.xml
+++ b/test/fixtures/fixed_layout.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ONIXMessage xmlns="http://www.editeur.org/onix/3.0/reference" release="3.0">
+<Header>
+  <Sender>
+    <SenderName>immatériel·fr</SenderName>
+  </Sender>
+  <SentDateTime>20130802</SentDateTime>
+  <DefaultLanguageOfText>fre</DefaultLanguageOfText>
+</Header>
+<Product>
+  <RecordReference>immateriel.fr-RP64127</RecordReference>
+  <NotificationType>03</NotificationType>
+  <ProductIdentifier>
+    <ProductIDType>01</ProductIDType>
+    <IDValue>RP64127</IDValue>
+  </ProductIdentifier>
+  <ProductIdentifier>
+    <ProductIDType>03</ProductIDType>
+    <IDValue>3019002489901</IDValue>
+  </ProductIdentifier>
+  <DescriptiveDetail>
+    <ProductComposition>00</ProductComposition>
+    <ProductForm>ED</ProductForm>
+    <ProductFormDetail>E101</ProductFormDetail>
+    <ProductFormDetail>E201</ProductFormDetail>
+    <ProductFormDescription>ePub fixed layout avec Tatouage</ProductFormDescription>
+    <ProductContentType>10</ProductContentType>
+    <EpubTechnicalProtection>02</EpubTechnicalProtection>
+    <EpubUsageConstraint>
+      <EpubUsageType>02</EpubUsageType>
+      <EpubUsageStatus>01</EpubUsageStatus>
+    </EpubUsageConstraint>
+    <EpubUsageConstraint>
+      <EpubUsageType>03</EpubUsageType>
+      <EpubUsageStatus>01</EpubUsageStatus>
+    </EpubUsageConstraint>
+    <EpubUsageConstraint>
+      <EpubUsageType>04</EpubUsageType>
+      <EpubUsageStatus>01</EpubUsageStatus>
+    </EpubUsageConstraint>
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleElementLevel>01</TitleElementLevel>
+        <TitleText>Certaines n'avaient jamais vu la mer</TitleText>
+      </TitleElement>
+    </TitleDetail>
+    <Extent>
+      <ExtentType>22</ExtentType>
+      <ExtentValue>480211</ExtentValue>
+      <ExtentUnit>17</ExtentUnit>
+    </Extent>
+  </DescriptiveDetail>
+  <RelatedMaterial>
+    <RelatedProduct>
+      <ProductRelationCode>02</ProductRelationCode>
+      <ProductIdentifier>
+        <ProductIDType>01</ProductIDType>
+        <IDValue>O192530</IDValue>
+      </ProductIdentifier>
+      <ProductIdentifier>
+        <ProductIDType>03</ProductIDType>
+        <IDValue>9782752908643</IDValue>
+      </ProductIdentifier>
+      <ProductIdentifier>
+        <ProductIDType>15</ProductIDType>
+        <IDValue>9782752908643</IDValue>
+      </ProductIdentifier>
+    </RelatedProduct>
+  </RelatedMaterial>
+  <ProductSupply>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>03</SupplierRole>
+        <SupplierIdentifier>
+          <SupplierIDType>02</SupplierIDType>
+          <IDValue>D1</IDValue>
+        </SupplierIdentifier>
+        <SupplierIdentifier>
+          <SupplierIDType>06</SupplierIDType>
+          <IDValue>3012410001000</IDValue>
+        </SupplierIdentifier>
+        <SupplierName>immatériel·fr</SupplierName>
+      </Supplier>
+      <ProductAvailability>45</ProductAvailability>
+      <UnpricedItemType>03</UnpricedItemType>
+    </SupplyDetail>
+  </ProductSupply>
+</Product>
+</ONIXMessage>

--- a/test/fixtures/reflowable.xml
+++ b/test/fixtures/reflowable.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ONIXMessage xmlns="http://www.editeur.org/onix/3.0/reference" release="3.0">
+<Header>
+  <Sender>
+    <SenderName>immatériel·fr</SenderName>
+  </Sender>
+  <SentDateTime>20130802</SentDateTime>
+  <DefaultLanguageOfText>fre</DefaultLanguageOfText>
+</Header>
+<Product>
+  <RecordReference>immateriel.fr-RP64127</RecordReference>
+  <NotificationType>03</NotificationType>
+  <ProductIdentifier>
+    <ProductIDType>01</ProductIDType>
+    <IDValue>RP64127</IDValue>
+  </ProductIdentifier>
+  <ProductIdentifier>
+    <ProductIDType>03</ProductIDType>
+    <IDValue>3019002489901</IDValue>
+  </ProductIdentifier>
+  <DescriptiveDetail>
+    <ProductComposition>00</ProductComposition>
+    <ProductForm>ED</ProductForm>
+    <ProductFormDetail>E101</ProductFormDetail>
+    <ProductFormDetail>E200</ProductFormDetail>
+    <ProductFormDescription>ePub avec Tatouage</ProductFormDescription>
+    <ProductContentType>10</ProductContentType>
+    <EpubTechnicalProtection>02</EpubTechnicalProtection>
+    <EpubUsageConstraint>
+      <EpubUsageType>02</EpubUsageType>
+      <EpubUsageStatus>01</EpubUsageStatus>
+    </EpubUsageConstraint>
+    <EpubUsageConstraint>
+      <EpubUsageType>03</EpubUsageType>
+      <EpubUsageStatus>01</EpubUsageStatus>
+    </EpubUsageConstraint>
+    <EpubUsageConstraint>
+      <EpubUsageType>04</EpubUsageType>
+      <EpubUsageStatus>01</EpubUsageStatus>
+    </EpubUsageConstraint>
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleElementLevel>01</TitleElementLevel>
+        <TitleText>Certaines n'avaient jamais vu la mer</TitleText>
+      </TitleElement>
+    </TitleDetail>
+    <Extent>
+      <ExtentType>22</ExtentType>
+      <ExtentValue>480211</ExtentValue>
+      <ExtentUnit>17</ExtentUnit>
+    </Extent>
+  </DescriptiveDetail>
+  <RelatedMaterial>
+    <RelatedProduct>
+      <ProductRelationCode>02</ProductRelationCode>
+      <ProductIdentifier>
+        <ProductIDType>01</ProductIDType>
+        <IDValue>O192530</IDValue>
+      </ProductIdentifier>
+      <ProductIdentifier>
+        <ProductIDType>03</ProductIDType>
+        <IDValue>9782752908643</IDValue>
+      </ProductIdentifier>
+      <ProductIdentifier>
+        <ProductIDType>15</ProductIDType>
+        <IDValue>9782752908643</IDValue>
+      </ProductIdentifier>
+    </RelatedProduct>
+  </RelatedMaterial>
+  <ProductSupply>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>03</SupplierRole>
+        <SupplierIdentifier>
+          <SupplierIDType>02</SupplierIDType>
+          <IDValue>D1</IDValue>
+        </SupplierIdentifier>
+        <SupplierIdentifier>
+          <SupplierIDType>06</SupplierIDType>
+          <IDValue>3012410001000</IDValue>
+        </SupplierIdentifier>
+        <SupplierName>immatériel·fr</SupplierName>
+      </Supplier>
+      <ProductAvailability>45</ProductAvailability>
+      <UnpricedItemType>03</UnpricedItemType>
+    </SupplyDetail>
+  </ProductSupply>
+</Product>
+</ONIXMessage>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -53,6 +53,12 @@ class TestImOnix < Minitest::Test
       assert_equal 3, @product.parts.length
     end
 
+    should "have parts that do not provide info about fixed layout or not" do
+      @product.parts.each do |part|
+        assert_equal nil, part.reflowable?
+      end
+    end
+
     should "have author named" do
       assert_equal "Julie Otsuka", @product.contributors.first.name
     end

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -77,6 +77,34 @@ class TestImOnix < Minitest::Test
       assert_equal "immatériel·fr", @message.sender.name
       assert_equal nil, @message.sender.gln
     end
+
+    should "not provide info about fixed layout or not" do
+      assert_equal nil, @product.reflowable?
+    end
+  end
+
+  context "reflowable epub" do
+      setup do
+        @message = ONIX::ONIXMessage.new
+        @message.parse("test/fixtures/reflowable.xml")
+        @product = @message.products.last
+      end
+
+      should "be reflowable" do
+        assert_equal true, @product.reflowable?
+      end
+  end
+
+  context "epub fixed layout" do
+      setup do
+        @message = ONIX::ONIXMessage.new
+        @message.parse("test/fixtures/fixed_layout.xml")
+        @product = @message.products.last
+      end
+
+      should "not be reflowable" do
+        assert_equal false, @product.reflowable?
+      end
   end
 
   context "prices with past change time" do


### PR DESCRIPTION
We want to know if a product is explicitly "reflowable" or "fixed layout".

Thus we added a method `reflowable?` : 
* true if the ONIX mentions the epub is reflowable,
* false if it is explicitly "fixed layout",
* nil if nothing is mentioned on this in the ONIX.