### PR TITLE
Return nil instead of "Undefined"

### DIFF
--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -121,11 +121,7 @@ module ONIX
     # :category: High level
     # digital file format string (Epub,Pdf,AmazonKindle)
     def file_format
-      if self.file_formats.first
-        self.file_formats.first.human
-      else
-        "Undefined"
-      end
+      self.file_formats.first.human if self.file_formats.first
     end
 
     def file_mimetype
@@ -394,11 +390,7 @@ module ONIX
     end
 
     def file_format
-      if self.file_formats.first
-        self.file_formats.first.human
-      else
-        "Undefined"
-      end
+      self.file_formats.first.human if self.file_formats.first
     end
 
     def file_mimetype
@@ -427,8 +419,6 @@ module ONIX
         else
           raise ExpectsOneButHasSeveral, @epub_technical_protections.map(&:type)
         end
-      else
-        "Undefined"
       end
     end
 

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -33,6 +33,10 @@ class TestImOnix < Minitest::Test
       assert_equal "Certaines n'avaient jamais vu la mer", @product.title
     end
 
+    should "have no format" do
+      assert_equal nil, @product.file_format
+    end
+
     should "have publisher name" do
       assert_equal "Phébus", @product.publisher_name
     end
@@ -102,15 +106,27 @@ class TestImOnix < Minitest::Test
   end
 
   context "epub fixed layout" do
-      setup do
-        @message = ONIX::ONIXMessage.new
-        @message.parse("test/fixtures/fixed_layout.xml")
-        @product = @message.products.last
-      end
+    setup do
+      @message = ONIX::ONIXMessage.new
+      @message.parse("test/fixtures/fixed_layout.xml")
+      @product = @message.products.last
+    end
 
-      should "not be reflowable" do
-        assert_equal false, @product.reflowable?
-      end
+    should "not be reflowable" do
+      assert_equal false, @product.reflowable?
+    end
+  end
+
+  context 'epub part of "Certaines n’avaient jamais vu la mer"' do
+    setup do
+      @message = ONIX::ONIXMessage.new
+      @message.parse("test/fixtures/9782752906700.xml")
+      @product=@message.products[1]
+    end
+
+    should "have epub file format" do
+      assert_equal "Epub", @product.file_format
+    end
   end
 
   context "prices with past change time" do


### PR DESCRIPTION
Some methods return `nil` when the information is not provided in the ONIX file. A few methods, though, return the string "Undefined".

We changed this behaviour in our fork because we want a more predictable behavior: always checking `nil` is easier than checking sometimes `nil` and sometimes `"Undefined"`.

We like it better this way, but this is a breaking change for existing users. :warning: 
We discussed it internally before sending the PR (https://github.com/TEA-ebook/im_onix/pull/5), we won't be angry at all if you don't merge. ;)