### PR TITLE
[Gemspec] Remove Warning

### DIFF
--- a/im_onix.gemspec
+++ b/im_onix.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
     "bin/onix3_to_onix2.rb",
     "bin/onix3_to_onix3.rb",
     "bin/onix_bench.rb",
-    "bin/onix_db.rb",
     "bin/onix_pp.rb",
     "bin/onix_split.rb",
     "data/codelists/codelist-1.yml",


### PR DESCRIPTION
The validation message from Rubygems was:

    ["bin/onix_db.rb"] are not files