### PR TITLE
Add CollectionSequence to Collection

### DIFF
--- a/lib/onix/code.rb
+++ b/lib/onix/code.rb
@@ -400,6 +400,13 @@ module ONIX
     end
   end
 
+  class CollectionSequenceType < CodeFromYaml
+    private
+    def self.code_ident
+      197
+    end
+  end
+
   class TitleElementLevel < CodeFromYaml
     private
     def self.code_ident

--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -57,10 +57,29 @@ module ONIX
     end
   end
 
+  class CollectionSequence < SubsetDSL
+    element "CollectionSequenceType", :subset
+    element "CollectionSequenceTypeName", :string
+    element "CollectionSequenceNumber", :string
+
+    def type
+      @collection_sequence_number
+    end
+
+    def number
+      @collection_sequence_number
+    end
+
+    def type_name
+      @collection_sequence_type_name
+    end
+  end
+
   class Collection < SubsetDSL
     element "CollectionType", :subset
     elements "CollectionIdentifier", :subset
     elements "TitleDetail", :subset
+    elements "CollectionSequence", :subset
 
     scope :publisher, lambda { human_code_match(:collection_type, "PublisherCollection")}
 
@@ -71,6 +90,10 @@ module ONIX
 
     def identifiers
       @collection_identifiers
+    end
+
+    def sequences
+      @collection_sequences
     end
 
     # :category: High level

--- a/test/fixtures/test_collection.xml
+++ b/test/fixtures/test_collection.xml
@@ -1,0 +1,24 @@
+<Collection>
+  <CollectionType>10</CollectionType>
+  <CollectionIdentifier>
+    <CollectionIDType>01</CollectionIDType>
+    <IDTypeName>Serie</IDTypeName>
+    <IDValue>237</IDValue>
+  </CollectionIdentifier>
+  <CollectionSequence>
+    <CollectionSequenceType>03</CollectionSequenceType>
+    <CollectionSequenceNumber>3</CollectionSequenceNumber>
+  </CollectionSequence>
+  <TitleDetail>
+    <TitleType>01</TitleType><TitleElement>
+      <TitleElementLevel>02</TitleElementLevel>
+      <TitleText><![CDATA[Hors Collection]]></TitleText>
+      </TitleElement><TitleElement>
+      <TitleElementLevel>03</TitleElementLevel>
+      <TitleText><![CDATA[Nom de Série]]></TitleText>
+      </TitleElement><TitleElement>
+      <TitleElementLevel>01</TitleElementLevel>
+      <TitleText><![CDATA[Tome 3]]></TitleText>
+      </TitleElement><TitleStatement><![CDATA[Un test pour les collections]]></TitleStatement>
+  </TitleDetail>
+</Collection>

--- a/test/test_collection.rb
+++ b/test/test_collection.rb
@@ -1,0 +1,23 @@
+require 'helper'
+
+class TestCollection < Minitest::Test
+  context "type" do
+    setup do
+      xml = ONIX::ONIXMessage.new.open("test/fixtures/test_collection.xml")
+      @collection = ONIX::Collection.new
+      @collection.parse(xml.root)
+    end
+
+    should "have a type" do
+      assert_equal "10", @collection.type.code
+    end
+
+    should "have identifiers" do
+      assert_equal "237", @collection.identifiers.first.value
+    end
+
+    should "have a sequence" do
+      assert_equal "3", @collection.sequences.first.number
+    end
+  end
+end


### PR DESCRIPTION
Bonjour,

En cherchant à ajouter le numéro de volume de livres qui nous sont envoyés, je me suis rendu compte que la version courante de la gemme ne parse pas le `CollectionSequence`, qui est inclus dans `Collection`.

Cette balise a été ajoutée dans les spécifications `3.0.1`.

Quelques libertés prises par rapport au code source:
- Tous les tests sont dans `test/test_im_onix.rb`. Comme ici je ne teste que les collections, j'ai fait un autre fichier `test/test_collection.rb`
- Les fixtures comprennent habituellement un `Product` complet, mais je me suis focalisé sur la `Collection`, et la fixture `test/fixtures/test_collection.xml` contient seulement la partie XML qui m'intéressait.