### PR TITLE
NotYetAvailable should not make the product available

### DIFF
--- a/lib/onix/product_supply.rb
+++ b/lib/onix/product_supply.rb
@@ -38,7 +38,7 @@ module ONIX
     end
 
     def available?
-      ["Available","NotYetAvailable","InStock","ToOrder","Pod"].include?(@product_availability.human)
+      ["Available","InStock","ToOrder","Pod"].include?(@product_availability.human)
     end
 
     def sold_separately?


### PR DESCRIPTION
Bonjour !

Une petite modification qui a du sens pour nous, mais peut-être pas pour vous. De plus, c'est une breaking change, nous comprendrions donc que vous la rejetiez. Je fais surtout la PR pour tenter de clarifier le sujet.

Nous interprétons `NotYetAvailable` comme "non disponible". Pour quelle raisons voyez vous cette valeur comme signifiant "disponible" ?  Peut-être car on peut considérer le produit comme pré-commandable ?