### PR TITLE
Add support for ContributorDate tag

### DIFF
--- a/lib/onix/code.rb
+++ b/lib/onix/code.rb
@@ -533,6 +533,13 @@ module ONIX
     end
   end
 
+  class ContributorDateRole < CodeFromYaml
+    private
+    def self.code_ident
+      177
+    end
+  end
+
   class SupportingResourceFileFormat < CodeFromYamlWithMime
     private
     def self.code_ident

--- a/lib/onix/contributor.rb
+++ b/lib/onix/contributor.rb
@@ -17,6 +17,8 @@ module ONIX
     elements "Website", :subset
     element "ContributorPlace", :subset
 
+    elements "ContributorDate", :subset
+
     def role
       @contributor_role
     end
@@ -31,6 +33,10 @@ module ONIX
 
     def name_before_key
       @names_before_key
+    end
+
+    def dates
+      @contributor_dates
     end
 
     # :category: High level
@@ -66,6 +72,26 @@ module ONIX
     def raw_biography
       if self.biography
         Helper.strip_html(self.biography).gsub(/\s+/, " ")
+      else
+        nil
+      end
+    end
+
+    # :category: High level
+    # date of birth
+    def birth_date
+      if contributor_date = @contributor_dates.find { |d| d.role.human == "DateOfBirth" }
+        contributor_date.date.to_time
+      else
+        nil
+      end
+    end
+
+    # :category: High level
+    # date of death
+    def death_date
+      if contributor_date = @contributor_dates.find { |d| d.role.human == "DateOfDeath" }
+        contributor_date.date.to_time
       else
         nil
       end

--- a/lib/onix/date.rb
+++ b/lib/onix/date.rb
@@ -180,4 +180,20 @@ module ONIX
       parse_date(n)
     end
   end
+
+  class ContributorDate < SubsetDSL
+    include DateHelper
+    element "Date", :ignore
+    element "DateFormat", :ignore
+    element "ContributorDateRole", :subset
+
+    def role
+      @contributor_date_role
+    end
+
+    def parse(n)
+      super
+      parse_date(n)
+    end
+  end
 end

--- a/test/fixtures/9782752906700.xml
+++ b/test/fixtures/9782752906700.xml
@@ -341,6 +341,14 @@
       <Website>
         <WebsiteLink>http://www.julieotsuka.com/</WebsiteLink>
       </Website>
+      <ContributorDate>
+        <ContributorDateRole>50</ContributorDateRole>
+        <Date>19891109</Date>
+      </ContributorDate>
+      <ContributorDate>
+        <ContributorDateRole>51</ContributorDateRole>
+        <Date>20190902</Date>
+      </ContributorDate>
     </Contributor>
     <EditionNumber>1</EditionNumber>
     <Language>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -269,6 +269,26 @@ class TestImOnix < Minitest::Test
     end
   end
 
+  context "author with date informations" do
+    setup do
+      @message = ONIX::ONIXMessage.new
+      @message.parse("test/fixtures/9782752906700.xml")
+      @product=@message.products.last
+    end
+
+    should "have two dates" do
+      assert_equal 2, @product.contributors.first.dates.length
+    end
+
+    should "have author birth date" do
+      assert_equal Time.new(1989, 11, 9), @product.contributors.first.birth_date
+    end
+
+    should "have author death date" do
+      assert_equal Time.new(2019, 9, 2), @product.contributors.first.death_date
+    end
+  end
+
   context "prices with past change time" do
     setup do
       @message = ONIX::ONIXMessage.new


### PR DESCRIPTION
This PR add support for ContributorDate tag.

I've also add 2 high level API methods to have a quick access to a contributor birth and death dates.