### PR TITLE
Add CorporateName to Contributors

### DIFF
--- a/lib/onix/contributor.rb
+++ b/lib/onix/contributor.rb
@@ -13,6 +13,9 @@ module ONIX
     element "NamesBeforeKey", :text
     element "KeyNames", :text
 
+    element "CorporateName", :text
+    element "CorporateNameInverted", :text
+
     element "BiographicalNote", :text
     elements "Website", :subset
     element "ContributorPlace", :subset
@@ -42,23 +45,23 @@ module ONIX
     # :category: High level
     # flatten person name (firstname lastname)
     def name
-      if @person_name
-        @person_name
-      else
-        if @key_names
-          if @names_before_key
-            "#{@names_before_key} #{@key_names}"
-          else
-            @key_names
-          end
+      return @person_name if @person_name
+
+      if @key_names
+        if @names_before_key
+          return "#{@names_before_key} #{@key_names}"
+        else
+          return @key_names
         end
       end
+
+      @corporate_name
     end
 
     # :category: High level
     # inverted flatten person name
     def inverted_name
-      @person_name_inverted
+      @person_name_inverted || @corporate_name_inverted
     end
 
     # :category: High level

--- a/test/fixtures/9782752906700.xml
+++ b/test/fixtures/9782752906700.xml
@@ -337,6 +337,8 @@
       <PersonNameInverted>Otsuka, Julie</PersonNameInverted>
       <NamesBeforeKey>Julie</NamesBeforeKey>
       <KeyNames>Otsuka</KeyNames>
+      <CorporateName>Julie Otsuka</CorporateName>
+      <CorporateNameInverted>Otsuka, Julie</CorporateNameInverted>
       <BiographicalNote>&lt;p&gt;Julie Otsuka est n&amp;eacute;e en 1962 en Californie. Dipl&amp;ocirc;m&amp;eacute;e en art, elle abandonne une carri&amp;egrave;re de peintre (elle a &amp;eacute;tudi&amp;eacute; cette discipline &amp;agrave; l'universit&amp;eacute; de Yale) pour l'&amp;eacute;criture. Elle publie son premier roman en 2002, &lt;em&gt;Quand l'empereur &amp;eacute;tait un dieu &lt;/em&gt;(Ph&amp;eacute;bus, 2004 ; 10/18, 2008) largement inspir&amp;eacute; de la vie de ses grands-parents. Son deuxi&amp;egrave;me roman, &lt;em&gt;Certaines n'avaient jamais vu la mer &lt;/em&gt;(Ph&amp;eacute;bus, 2012) a &amp;eacute;t&amp;eacute; consid&amp;eacute;r&amp;eacute; aux &amp;Eacute;tats-Unis, d&amp;egrave;s sa sortie, comme un chef-d'oeuvre. Julie Otsuka vit &amp;agrave; New York.&lt;/p&gt;</BiographicalNote>
       <Website>
         <WebsiteLink>http://www.julieotsuka.com/</WebsiteLink>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -165,6 +165,14 @@ class TestImOnix < Minitest::Test
       assert_equal "Julie", @product.contributors.first.name_before_key
     end
 
+    should "have corporate name" do
+      assert_equal "Julie Otsuka", @product.contributors.first.corporate_name
+    end
+
+    should "have inverted corporate name" do
+      assert_equal "Otsuka, Julie", @product.contributors.first.corporate_name_inverted
+    end
+
     should "have author biography" do
       assert_equal "<p>Julie Otsuka est n&eacute;e en 1962 en Californie. Dipl&ocirc;m&eacute;e en art, elle abandonne une carri&egrave;re de peintre (elle a &eacute;tudi&eacute; cette discipline &agrave; l'universit&eacute; de Yale) pour l'&eacute;criture. Elle publie son premier roman en 2002, <em>Quand l'empereur &eacute;tait un dieu </em>(Ph&eacute;bus, 2004 ; 10/18, 2008) largement inspir&eacute; de la vie de ses grands-parents. Son deuxi&egrave;me roman, <em>Certaines n'avaient jamais vu la mer </em>(Ph&eacute;bus, 2012) a &eacute;t&eacute; consid&eacute;r&eacute; aux &Eacute;tats-Unis, d&egrave;s sa sortie, comme un chef-d'oeuvre. Julie Otsuka vit &agrave; New York.</p>", @product.contributors.first.biography
     end


### PR DESCRIPTION
This PR adds the ability to get corporate names of contributors, and use them as default name when no person name is given.