### PR TITLE
Add TitleStatement to TitleDetail

### DIFF
--- a/lib/onix/descriptive_detail.rb
+++ b/lib/onix/descriptive_detail.rb
@@ -38,6 +38,7 @@ module ONIX
   class TitleDetail < SubsetDSL
     element "TitleType", :subset
     elements "TitleElement", :subset
+    element "TitleStatement", :text
 
     scope :distinctive_title, lambda { human_code_match(:title_type, /DistinctiveTitle/)}
 
@@ -48,6 +49,8 @@ module ONIX
     # :category: High level
     # flatten title string
     def title
+      return title_statement if title_statement
+
       title_element = @title_elements.product_level #select { |te| te.level.human=~/Product/ }
       if title_element.size > 0
         title_element.first.title

--- a/test/test_title.rb
+++ b/test/test_title.rb
@@ -1,0 +1,55 @@
+require 'helper'
+
+class TestTitle < Minitest::Test
+  def create_title_detail(xml)
+    message = ONIX::ONIXMessage.new.open(xml)
+    detail = ONIX::TitleDetail.new
+    detail.parse(message.root)
+    detail
+  end
+
+  context "when it has a title element for level 1" do
+    setup do
+      @title_detail = create_title_detail <<~XML
+        <TitleDetail>
+          <TitleType>01</TitleType>
+          <TitleElement>
+            <TitleElementLevel>02</TitleElementLevel>
+            <TitleText><![CDATA[Hors Collection]]></TitleText>
+          </TitleElement>
+          <TitleElement>
+            <TitleElementLevel>03</TitleElementLevel>
+            <TitleText><![CDATA[Nom de Série]]></TitleText>
+          </TitleElement>
+          <TitleElement>
+            <TitleElementLevel>01</TitleElementLevel>
+            <TitleText><![CDATA[Le Titre]]></TitleText>
+          </TitleElement>
+        </TitleDetail>
+      XML
+    end
+
+    should "retrieve the title" do
+      assert_equal "Le Titre", @title_detail.title
+    end
+  end
+
+  context "when it has a title statement" do
+    setup do
+      @title_detail = create_title_detail <<~XML
+          <TitleDetail>
+            <TitleType>01</TitleType>
+            <TitleElement>
+              <TitleElementLevel>01</TitleElementLevel>
+              <TitleText><![CDATA[Le Titre]]></TitleText>
+            </TitleElement>
+            <TitleStatement><![CDATA[Le Titre à afficher]]></TitleStatement>
+          </TitleDetail>
+      XML
+    end
+
+    should "retrieve the title from the title statement" do
+      assert_equal "Le Titre à afficher", @title_detail.title
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for the TitleStatement tag in TitleDetail.

TitleStatement is a tag we can use to display the title.

As specified here: https://www.editeur.org/files/ONIX%203/Changes%20for%20ONIX%203.0.1.pdf

```
<TitleStatement> has been added to carry the complete collection and main title, in the order
and with any interposed punctuation that the publisher prefers. This should be used for
display purposes only. Note that provision of an unstructured title statement as the sole title
metadata is not acceptable – the structured title is still required.
```

I added it as the default `TitleDetail#title`. I am not sure whether you want to do that or if you want to keep separated from the `title`.