### PR TITLE
include IsbnMethods in Onix 2.1 product

### DIFF
--- a/lib/onix/onix21.rb
+++ b/lib/onix/onix21.rb
@@ -312,6 +312,7 @@ module ONIX
 
     class Product < SubsetDSL
       include EanMethods
+      include IsbnMethods
       include ProprietaryIdMethods
 
       element "RecordReference", :text

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -24,6 +24,14 @@ class TestImOnix < Minitest::Test
       assert_equal 1, @product.edition_number
     end
 
+    should "have an EAN13" do
+      assert_equal "9780470020043", @product.ean
+    end
+
+    should "have an ISBN-13" do
+      assert_equal "9780470020043", @product.isbn13
+    end
+
     should "have a frontcover_url" do
       assert_equal "http://TEST.com/images/db/jimages/9780470095003.jpg", @product.frontcover_url
     end


### PR DESCRIPTION
Closes #85 by including the `IsbnMethods` module in the `ONIX::ONIX21::Product` class. 