### PR TITLE
Add support for OtherText text link in Onix 2

### DIFF
--- a/lib/onix/onix21.rb
+++ b/lib/onix/onix21.rb
@@ -103,6 +103,8 @@ module ONIX
       element "TextTypeCode", :subset
       element "TextFormat", :text
       element "Text", :text
+      element "TextLinkType", :text
+      element "TextLink", :text
 
       def type
         @text_type_code

--- a/test/fixtures/onix2.xml
+++ b/test/fixtures/onix2.xml
@@ -58,6 +58,12 @@
       <TextFormat>02</TextFormat>
       <Text><![CDATA[<p>L’esprit étant l’ensemble des fonctions de relation de l’être vivant et des manières d’être internes qui s’y rapportent le plus directement, peut être considéré, à un certain point de vue, comme l’expression de l’organisme. Il est en quelque sorte l’activité même de cet organisme, et c’est de son nom que nous appelons cet ensemble de fonctions qui reçoit les impressions du dehors, qui les trie, les analyse, puis les classe, les compare, les synthétise et réagit selon sa nature propre, en des manières très diverses.</p><p>Fruit d’une sélection réalisée au sein des fonds de la Bibliothèque nationale de France, <i>Collection XIX</i> a pour ambition de faire découvrir des textes classiques et moins classiques dans les meilleures éditions du XIX<sup>e</sup> siècle.</p>]]></Text>
     </OtherText>
+    <OtherText>
+      <TextTypeCode>23</TextTypeCode>
+      <TextFormat>14</TextFormat>
+      <TextLinkType>01</TextLinkType>
+      <TextLink>https://dummy.excerpt.link</TextLink>
+    </OtherText>
     <SupplyDetail>
       <SupplierName>Jouve</SupplierName>
       <ProductAvailability>20</ProductAvailability>

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -888,6 +888,13 @@ class TestImOnix < Minitest::Test
     should "be priced in France" do
       assert_equal 149, @product.supplies_for_country("FR", "EUR").first[:prices].first[:amount]
     end
+
+    should "have an excerpt with a link" do
+      other_text_excerpt_code = "23"
+      excerpt = @product.other_texts.select {|other_text| other_text.text_type_code.code == other_text_excerpt_code}[0]
+      assert_equal "https://dummy.excerpt.link", excerpt.text_link
+      assert_equal "01", excerpt.text_link_type
+    end
   end
 
   context "with YYYY date format" do


### PR DESCRIPTION
This PR add support for the `OtherText`'s `TextLink` and `TextLinkType` : it can be used to link excerpts from books in Onix2.