### PR TITLE
allow multiple tax statements

### DIFF
--- a/lib/onix/onix21.rb
+++ b/lib/onix/onix21.rb
@@ -167,8 +167,8 @@ module ONIX
         Territory.new(@country_codes)
       end
 
-      def tax
-        nil
+      def taxes
+        []
       end
     end
 

--- a/lib/onix/price.rb
+++ b/lib/onix/price.rb
@@ -36,7 +36,7 @@ module ONIX
               :serialize_lambda => lambda { |v| format("%.2f", v / 100.0) },
               :cardinality => 0..1
             }
-    element "Tax", :subset, :cardinality => 0..n
+    elements "Tax", :subset, :cardinality => 0..n
     element "TaxExempt", :bool, :cardinality => 0..1
     element "UnpricedItemType", :subset, :cardinality => 0..1
     element "CurrencyCode", :text, :shortcut => :currency, :cardinality => 0..1

--- a/lib/onix/product_supplies_methods.rb
+++ b/lib/onix/product_supplies_methods.rb
@@ -56,7 +56,7 @@ module ONIX
               supply[:from_date] = price.from_date
               supply[:until_date] = price.until_date
               supply[:currency] = price.currency
-              supply[:tax] = price.tax
+              supply[:taxes] = price.taxes
 
               unless supply[:availability_date]
                 if @publishing_detail


### PR DESCRIPTION
We came across onix messages with multiple tax statements. This PR changes the `price.tax` call into `price.taxes` to support such cases.