### PR TITLE
Change publishing date order of assignment

### DIFF
--- a/im_onix.gemspec
+++ b/im_onix.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "im_onix"
-  spec.version       = "1.3.5"
+  spec.version       = "1.3.6"
   spec.authors       = ["Julien Boulnois"]
   spec.email         = ["jboulnois@immateriel.fr"]
 

--- a/lib/onix/product_supplies_methods.rb
+++ b/lib/onix/product_supplies_methods.rb
@@ -29,17 +29,9 @@ module ONIX
         self.product_supplies.each do |product_supply|
           product_supply.supply_details.each do |supply_detail|
 
-            availability_date = product_supply.market_publishing_detail&.availability_date
-
-            unless availability_date
-              availability_date = supply_detail.availability_date
-            end
-
-            unless availability_date
-              if @publishing_detail
-                availability_date = @publishing_detail.publication_date
-              end
-            end
+            availability_date = product_supply.market_publishing_detail&.availability_date ||
+                                supply_detail.availability_date ||
+                                @publishing_detail&.publication_date
 
             supply_detail.prices.each do |price|
               supply = {}

--- a/lib/onix/product_supplies_methods.rb
+++ b/lib/onix/product_supplies_methods.rb
@@ -29,12 +29,12 @@ module ONIX
         self.product_supplies.each do |product_supply|
           product_supply.supply_details.each do |supply_detail|
 
-            availability_date = supply_detail.availability_date
+            availability_date = product_supply.market_publishing_detail&.availability_date
+
             unless availability_date
-              if product_supply.availability_date
-                availability_date = product_supply.market_publishing_detail.availability_date
-              end
+              availability_date = supply_detail.availability_date
             end
+
             unless availability_date
               if @publishing_detail
                 availability_date = @publishing_detail.publication_date

--- a/test/fixtures/test_prices1.xml
+++ b/test/fixtures/test_prices1.xml
@@ -919,4 +919,32 @@
       </Price>
     </SupplyDetail>
   </ProductSupply>
+  <ProductSupply>
+    <MarketPublishingDetail>
+      <MarketPublishingStatus>04</MarketPublishingStatus>
+      <MarketDate>
+        <MarketDateRole>01</MarketDateRole>
+        <Date>20250309</Date>
+      </MarketDate>
+    </MarketPublishingDetail>
+    <SupplyDetail>
+      <Supplier>
+        <SupplierRole>06</SupplierRole>
+        <SupplierName>XXX</SupplierName>
+      </Supplier>
+      <ProductAvailability>20</ProductAvailability>
+      <SupplyDate>
+        <SupplyDateRole>08</SupplyDateRole>
+        <Date>20250207</Date>
+      </SupplyDate>
+      <Price>
+        <PriceType>03</PriceType>
+        <PriceAmount>14.99</PriceAmount>
+        <CurrencyCode>CAD</CurrencyCode>
+        <Territory>
+          <CountriesIncluded>CA</CountriesIncluded>
+        </Territory>
+      </Price>
+    </SupplyDetail>
+  </ProductSupply>
 </Product>

--- a/test/test_prices.rb
+++ b/test/test_prices.rb
@@ -27,6 +27,10 @@ class TestPrices < Minitest::Test
     should "not have a price to be announced" do
       assert_equal false, @product.price_to_be_announced?
     end
+
+    should "use MarketDate instead of SupplyDate for Canada availability date" do
+      assert_equal Date.new(2025, 3, 9), @product.supplies_for_country("CA", "CAD").first[:availability_date]
+    end
   end
 
   context "prices starting free with date" do


### PR DESCRIPTION
Ref:  https://github.com/immateriel/Support-technique/issues/2464

**Previous order (incorect):** 

1. SupplyDate (from SupplyDetail)
2. MarketDate (from MarketPublishingDetail)
3. publication_date (from PublishingDetail)

This order created incorrect availabiliy dates for certain countries, as MarketDate is the one that carries the specific publication date for a specific country.

**:arrow_right:  New order of assignment:** 

1. MarketDate (from MarketPublishingDetail)
2. SupplyDate (from SupplyDetail)
3. publication_date (from PublishingDetail)