### PR TITLE
Fix: regression - method missing in Onix 21

### DIFF
--- a/im_onix.gemspec
+++ b/im_onix.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "im_onix"
-  spec.version       = "1.3.6"
+  spec.version       = "1.3.7"
   spec.authors       = ["Julien Boulnois"]
   spec.email         = ["jboulnois@immateriel.fr"]
 

--- a/lib/onix/onix21.rb
+++ b/lib/onix/onix21.rb
@@ -443,6 +443,10 @@ module ONIX
         nil
       end
 
+      def market_publishing_detail
+        nil
+      end
+
       include ProductSuppliesMethods
 
       # doesn't apply


### PR DESCRIPTION
Following https://github.com/immateriel/im_onix/pull/117

Failing test in immateriel after updating im_onix revealing the problem : 

```
ERROR SourceOnixTest#test_onix20 (441.81s)
Minitest::UnexpectedError:         RuntimeError: WARN market_publishing_detail not found
            vendor/bookworm/2.4.10/bundler/gems/im_onix-9c5e8ddf3716/lib/onix/onix21.rb:540:in `method_missing'
            vendor/bookworm/2.4.10/bundler/gems/im_onix-9c5e8ddf3716/lib/onix/product_supplies_methods.rb:32:in `block (2 levels) in supplies'
            vendor/bookworm/2.4.10/bundler/gems/im_onix-9c5e8ddf3716/lib/onix/product_supplies_methods.rb:30:in `each'
            vendor/bookworm/2.4.10/bundler/gems/im_onix-9c5e8ddf3716/lib/onix/product_supplies_methods.rb:30:in `block in supplies'
            vendor/bookworm/2.4.10/bundler/gems/im_onix-9c5e8ddf3716/lib/onix/product_supplies_methods.rb:29:in `each'
            vendor/bookworm/2.4.10/bundler/gems/im_onix-9c5e8ddf3716/lib/onix/product_supplies_methods.rb:29:in `supplies'
            vendor/bookworm/2.4.10/bundler/gems/im_onix-9c5e8ddf3716/lib/onix/product_supplies_methods.rb:241:in `supplies_for_country'
            app/services/book_flow/source_onix.rb:214:in `read'
            app/services/book_flow/base.rb:122:in `read_with_callback'
            app/services/book_flow/source_onix.rb:162:in `read_product'
            app/services/book_flow/source_onix.rb:144:in `block in read_message'
            app/services/book_flow/source_onix.rb:139:in `each'
            app/services/book_flow/source_onix.rb:139:in `read_message'
            app/services/book_flow/source_onix.rb:69:in `read_all'
            test/services/book_flow/source_onix_test.rb:79:in `test_onix20'
```

Precisely, the removal of this condition : https://github.com/immateriel/im_onix/pull/117/changes#diff-8ea42f0db25af6fe4bf78dc99f3fcf13e673b69e4831c99eaeea1d8654064f45L34
Before, `market_publishing_detail` wasn't called because `product_supply.availability_date` was `nil`